### PR TITLE
Add waypoint label offset configuration options

### DIFF
--- a/src/main/java/dev/xpple/simplewaypoints/impl/WaypointRenderingHelper.java
+++ b/src/main/java/dev/xpple/simplewaypoints/impl/WaypointRenderingHelper.java
@@ -110,7 +110,9 @@ public final class WaypointRenderingHelper {
                 double ab = 2 * av;
                 double am = right ? mv + av : ab - (mv + av);
                 double perc = am / ab;
-                x = (int) (perc * guiGraphics.guiWidth());
+                int guiWidth = guiGraphics.guiWidth();
+                int halfWidth = minecraft.font.width(label) / 2;
+                x = Math.clamp((int) (perc * guiWidth), halfWidth, guiWidth - halfWidth);
             }
             xPositions.add(new WaypointLabelLocation(label, x));
         });


### PR DESCRIPTION
Configs:
- waypointLabelRenderLeftOffsetComment
- waypointLabelRenderRightOffsetComment

Bugfix:
- Waypoint label is rendered partially outside of the screen when on edge
